### PR TITLE
ci: Connect the default shipping method to PayPal payment method 

### DIFF
--- a/Tests/E2E/helper/connectDefaultShippingMethodWithPayPalHelper.mjs
+++ b/Tests/E2E/helper/connectDefaultShippingMethodWithPayPalHelper.mjs
@@ -1,0 +1,21 @@
+import MysqlFactory from './mysqlFactory.mjs';
+import fs from 'fs';
+import path from 'path';
+
+const connectDefaultShippingMethodWithPayPalSql = fs.readFileSync(path.join(path.resolve(''), 'setup/sql/connect_default_shipping_method_with_paypal.sql'), 'utf8');
+const connection = MysqlFactory.getInstance();
+
+export default (function() {
+    return {
+        connectDefaultShippingMethodWithPayPal: async function() {
+            await new Promise((resolve, reject) => {
+                connection.query(connectDefaultShippingMethodWithPayPalSql, function(err) {
+                    if (err) {
+                        reject(err);
+                    }
+                    resolve();
+                });
+            });
+        }
+    };
+}());

--- a/Tests/E2E/setup/sql/connect_default_shipping_method_with_paypal.sql
+++ b/Tests/E2E/setup/sql/connect_default_shipping_method_with_paypal.sql
@@ -1,0 +1,5 @@
+SET @shippingMethodId = (SELECT id FROM `s_premium_dispatch` WHERE name='Standard Versand');
+SET @paymentMethodId = (SELECT id FROM `s_core_paymentmeans` WHERE name='SwagPaymentPayPalUnified');
+
+INSERT INTO `s_premium_dispatch_paymentmeans`(`dispatchID`, `paymentID`) VALUES (@shippingMethodId, @paymentMethodId)
+ON DUPLICATE KEY UPDATE `dispatchID` = `dispatchID`, `paymentID` = `paymentID`;

--- a/Tests/E2E/test/pay_with_express.spec.mjs
+++ b/Tests/E2E/test/pay_with_express.spec.mjs
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import MysqlFactory from '../helper/mysqlFactory.mjs';
 import defaultPaypalSettingsSql from '../helper/paypalSqlHelper.mjs';
 import clearCacheHelper from '../helper/clearCacheHelper.mjs';
+import connector from '../helper/connectDefaultShippingMethodWithPayPalHelper.mjs';
 import credentials from './credentials.mjs';
 import leadingZeroProductSql from '../helper/updateProductNumberAddLeadingZero.mjs';
 import tryUntilSucceed from '../helper/retryHelper.mjs';
@@ -11,6 +12,7 @@ const connection = MysqlFactory.getInstance();
 test.describe('Is Express Checkout button available', () => {
     test.beforeEach(async() => {
         await connection.query(defaultPaypalSettingsSql);
+        await connector.connectDefaultShippingMethodWithPayPal();
         await clearCacheHelper.clearCache();
     });
 


### PR DESCRIPTION
This should prevent that the cart amount is changed on the confirm page, which is not expected to happen in the E2E scenarios